### PR TITLE
implemented the internationalization (i18n)

### DIFF
--- a/src/languageSystem/controllers/i18n.controller.ts
+++ b/src/languageSystem/controllers/i18n.controller.ts
@@ -1,0 +1,85 @@
+import { Controller, Get, Post, Put, Delete, Param, Body, Query, Req } from '@nestjs/common';
+import { Request } from 'express';
+import { TranslationService } from '../services/translation.service';
+import { TranslationManagementService, TranslationEntry } from '../services/translation-management.service';
+import { LocaleDetectionService } from '../services/locale-detection.service';
+
+@Controller('i18n')
+export class I18nController {
+  constructor(
+    private readonly translationService: TranslationService,
+    private readonly managementService: TranslationManagementService,
+    private readonly localeService: LocaleDetectionService,
+  ) {}
+
+  @Get('detect')
+  detectLocale(@Req() req: Request) {
+    return this.localeService.detectLocale(req);
+  }
+
+  @Get('locales')
+  getSupportedLocales() {
+    return {
+      locales: this.translationService.getSupportedLocales(),
+      rtlLocales: this.translationService.getSupportedLocales()
+        .filter(locale => this.translationService.isRTLLanguage(locale)),
+    };
+  }
+
+  @Get('translate/:key')
+  translate(
+    @Param('key') key: string,
+    @Query('locale') locale?: string,
+    @Query('count') count?: string,
+  ) {
+    const options = {
+      locale,
+      count: count ? parseInt(count, 10) : undefined,
+    };
+
+    return {
+      key,
+      translation: this.translationService.translate(key, options),
+      locale: options.locale,
+    };
+  }
+
+  @Get('stats/:locale')
+  async getTranslationStats(@Param('locale') locale: string) {
+    return await this.managementService.getTranslationStats(locale);
+  }
+
+  @Post('translations')
+  async addTranslation(@Body() entry: TranslationEntry) {
+    await this.managementService.addTranslation(entry);
+    return { success: true };
+  }
+
+  @Delete('translations/:locale/:key')
+  async removeTranslation(
+    @Param('locale') locale: string,
+    @Param('key') key: string,
+  ) {
+    await this.managementService.removeTranslation(key, locale);
+    return { success: true };
+  }
+
+  @Get('export/:locale')
+  async exportTranslations(
+    @Param('locale') locale: string,
+    @Query('format') format: 'json' | 'csv' = 'json',
+  ) {
+    const data = await this.managementService.exportTranslations(locale, format);
+    return { data };
+  }
+
+  @Post('import/:locale')
+  async importTranslations(
+    @Param('locale') locale: string,
+    @Body('data') data: string,
+    @Body('format') format: 'json' | 'csv' = 'json',
+  ) {
+    await this.managementService.importTranslations(locale, data, format);
+    return { success: true };
+  }
+}

--- a/src/languageSystem/decorators/translate.decorator.ts
+++ b/src/languageSystem/decorators/translate.decorator.ts
@@ -1,0 +1,16 @@
+import { createParamDecorator, ExecutionContext } from '@nestjs/common';
+import { I18nContext } from 'nestjs-i18n';
+
+export const Translate = createParamDecorator(
+  (key: string, ctx: ExecutionContext) => {
+    const i18n = I18nContext.current();
+    return i18n?.translate(key) || key;
+  },
+);
+
+export const CurrentLocale = createParamDecorator(
+  (data: unknown, ctx: ExecutionContext) => {
+    const i18n = I18nContext.current();
+    return i18n?.lang || 'en';
+  },
+);

--- a/src/languageSystem/filters/i18n-validation.filter.ts
+++ b/src/languageSystem/filters/i18n-validation.filter.ts
@@ -1,0 +1,25 @@
+import { ExceptionFilter, Catch, ArgumentsHost, BadRequestException } from '@nestjs/common';
+import { Response } from 'express';
+import { I18nValidationException, I18nContext } from 'nestjs-i18n';
+
+@Catch(I18nValidationException)
+export class I18nValidationExceptionFilter implements ExceptionFilter {
+  catch(exception: I18nValidationException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+    const i18n = I18nContext.current(host);
+
+    const errors = exception.errors?.map(error => ({
+      property: error.property,
+      constraints: Object.values(error.constraints || {}).map(constraint =>
+        i18n?.translate(`validation.${constraint}`) || constraint
+      ),
+    }));
+
+    response.status(400).json({
+      statusCode: 400,
+      message: i18n?.translate('validation.failed') || 'Validation failed',
+      errors,
+    });
+  }
+}

--- a/src/languageSystem/i18n.module.ts
+++ b/src/languageSystem/i18n.module.ts
@@ -1,0 +1,38 @@
+import { Module, Global } from '@nestjs/common';
+import { AcceptLanguageResolver, I18nModule, QueryResolver, HeaderResolver } from 'nestjs-i18n';
+import { join } from 'path';
+import { TranslationService } from './services/translation.service';
+import { TranslationManagementService } from './services/translation-management.service';
+import { LocaleDetectionService } from './services/locale-detection.service';
+import { I18nController } from './controllers/i18n.controller';
+
+@Global()
+@Module({
+  imports: [
+    I18nModule.forRoot({
+      fallbackLanguage: 'en',
+      loaderOptions: {
+        path: join(__dirname, '/translations/'),
+        watch: true,
+      },
+      resolvers: [
+        { use: QueryResolver, options: ['lang'] },
+        { use: HeaderResolver, options: ['x-language'] },
+        AcceptLanguageResolver,
+      ],
+      typesOutputPath: join(__dirname, '../generated/i18n.generated.ts'),
+    }),
+  ],
+  providers: [
+    TranslationService,
+    TranslationManagementService,
+    LocaleDetectionService,
+  ],
+  controllers: [I18nController],
+  exports: [
+    TranslationService,
+    TranslationManagementService,
+    LocaleDetectionService,
+  ],
+})
+export class I18nLanguageModule {}

--- a/src/languageSystem/middleware/locale.middleware.ts
+++ b/src/languageSystem/middleware/locale.middleware.ts
@@ -1,0 +1,38 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { LocaleDetectionService } from '../services/locale-detection.service';
+import { TranslationService } from '../services/translation.service';
+
+@Injectable()
+export class LocaleMiddleware implements NestMiddleware {
+  constructor(
+    private readonly localeService: LocaleDetectionService,
+    private readonly translationService: TranslationService,
+  ) {}
+
+  use(req: Request, res: Response, next: NextFunction) {
+    const detection = this.localeService.detectLocale(req);
+    
+    // Set locale in request for later use
+    req['locale'] = detection.locale;
+    req['localeSource'] = detection.source;
+    
+    // Set response headers for client-side use
+    res.setHeader('X-Detected-Language', detection.locale);
+    res.setHeader('X-Language-Source', detection.source);
+    res.setHeader('X-Language-Direction', 
+      this.translationService.isRTLLanguage(detection.locale) ? 'rtl' : 'ltr'
+    );
+    
+    // Set cookie if not present and detected from other sources
+    if (detection.source !== 'cookie') {
+      res.cookie('locale', detection.locale, {
+        maxAge: 30 * 24 * 60 * 60 * 1000, // 30 days
+        httpOnly: false, // Allow client-side access
+        sameSite: 'lax',
+      });
+    }
+    
+    next();
+  }
+}

--- a/src/languageSystem/services/locale-detection.service.ts
+++ b/src/languageSystem/services/locale-detection.service.ts
@@ -1,0 +1,113 @@
+import { Injectable } from '@nestjs/common';
+import { Request } from 'express';
+
+export interface LocaleDetectionResult {
+  locale: string;
+  source: 'query' | 'header' | 'cookie' | 'default';
+  confidence: number;
+}
+
+@Injectable()
+export class LocaleDetectionService {
+  private readonly supportedLocales = ['en', 'es', 'fr', 'de', 'ar', 'zh', 'ja'];
+  private readonly defaultLocale = 'en';
+
+  detectLocale(req: Request): LocaleDetectionResult {
+    // Priority: Query -> Header -> Cookie -> Default
+    const queryLocale = this.getLocaleFromQuery(req);
+    if (queryLocale) {
+      return {
+        locale: queryLocale,
+        source: 'query',
+        confidence: 1.0,
+      };
+    }
+
+    const headerLocale = this.getLocaleFromHeader(req);
+    if (headerLocale) {
+      return {
+        locale: headerLocale.locale,
+        source: 'header',
+        confidence: headerLocale.confidence,
+      };
+    }
+
+    const cookieLocale = this.getLocaleFromCookie(req);
+    if (cookieLocale) {
+      return {
+        locale: cookieLocale,
+        source: 'cookie',
+        confidence: 0.8,
+      };
+    }
+
+    return {
+      locale: this.defaultLocale,
+      source: 'default',
+      confidence: 0.5,
+    };
+  }
+
+  private getLocaleFromQuery(req: Request): string | null {
+    const lang = req.query.lang as string;
+    return this.validateLocale(lang);
+  }
+
+  private getLocaleFromHeader(req: Request): { locale: string; confidence: number } | null {
+    const acceptLanguage = req.headers['accept-language'];
+    const customLanguage = req.headers['x-language'] as string;
+
+    if (customLanguage) {
+      const validated = this.validateLocale(customLanguage);
+      if (validated) {
+        return { locale: validated, confidence: 0.95 };
+      }
+    }
+
+    if (acceptLanguage) {
+      const parsed = this.parseAcceptLanguage(acceptLanguage);
+      for (const { locale, quality } of parsed) {
+        const validated = this.validateLocale(locale);
+        if (validated) {
+          return { locale: validated, confidence: quality };
+        }
+      }
+    }
+
+    return null;
+  }
+
+  private getLocaleFromCookie(req: Request): string | null {
+    const cookieLocale = req.cookies?.locale;
+    return this.validateLocale(cookieLocale);
+  }
+
+  private validateLocale(locale: string): string | null {
+    if (!locale) return null;
+    
+    const normalized = locale.toLowerCase().split('-')[0];
+    return this.supportedLocales.includes(normalized) ? normalized : null;
+  }
+
+  private parseAcceptLanguage(acceptLanguage: string): Array<{ locale: string; quality: number }> {
+    return acceptLanguage
+      .split(',')
+      .map(lang => {
+        const [locale, q] = lang.trim().split(';q=');
+        return {
+          locale: locale.trim(),
+          quality: q ? parseFloat(q) : 1.0,
+        };
+      })
+      .sort((a, b) => b.quality - a.quality);
+  }
+
+  getBrowserLocales(req: Request): string[] {
+    const acceptLanguage = req.headers['accept-language'];
+    if (!acceptLanguage) return [];
+
+    return this.parseAcceptLanguage(acceptLanguage)
+      .map(({ locale }) => locale.split('-')[0])
+      .filter((locale, index, array) => array.indexOf(locale) === index);
+  }
+}

--- a/src/languageSystem/services/translation-management.service.ts
+++ b/src/languageSystem/services/translation-management.service.ts
@@ -1,0 +1,208 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { promises as fs } from 'fs';
+import { join } from 'path';
+
+export interface TranslationEntry {
+  key: string;
+  value: string | Record<string, string>;
+  locale: string;
+  namespace?: string;
+}
+
+export interface TranslationStats {
+  totalKeys: number;
+  translatedKeys: number;
+  missingKeys: string[];
+  completionPercentage: number;
+}
+
+@Injectable()
+export class TranslationManagementService {
+  private readonly logger = new Logger(TranslationManagementService.name);
+  private readonly translationsPath = join(__dirname, '../translations');
+
+  async getTranslationStats(locale: string): Promise<TranslationStats> {
+    try {
+      const baseTranslations = await this.loadTranslations('en');
+      const targetTranslations = await this.loadTranslations(locale);
+
+      const baseKeys = this.flattenKeys(baseTranslations);
+      const targetKeys = this.flattenKeys(targetTranslations);
+
+      const missingKeys = baseKeys.filter(key => !targetKeys.includes(key));
+      const translatedKeys = baseKeys.filter(key => targetKeys.includes(key));
+
+      return {
+        totalKeys: baseKeys.length,
+        translatedKeys: translatedKeys.length,
+        missingKeys,
+        completionPercentage: Math.round((translatedKeys.length / baseKeys.length) * 100),
+      };
+    } catch (error) {
+      this.logger.error(`Error getting translation stats for ${locale}:`, error);
+      throw error;
+    }
+  }
+
+  async addTranslation(entry: TranslationEntry): Promise<void> {
+    try {
+      const filePath = join(this.translationsPath, `${entry.locale}.json`);
+      const translations = await this.loadTranslations(entry.locale);
+      
+      this.setNestedValue(translations, entry.key, entry.value);
+      
+      await fs.writeFile(filePath, JSON.stringify(translations, null, 2));
+      this.logger.log(`Added translation: ${entry.key} for locale ${entry.locale}`);
+    } catch (error) {
+      this.logger.error(`Error adding translation:`, error);
+      throw error;
+    }
+  }
+
+  async removeTranslation(key: string, locale: string): Promise<void> {
+    try {
+      const filePath = join(this.translationsPath, `${locale}.json`);
+      const translations = await this.loadTranslations(locale);
+      
+      this.deleteNestedValue(translations, key);
+      
+      await fs.writeFile(filePath, JSON.stringify(translations, null, 2));
+      this.logger.log(`Removed translation: ${key} for locale ${locale}`);
+    } catch (error) {
+      this.logger.error(`Error removing translation:`, error);
+      throw error;
+    }
+  }
+
+  async exportTranslations(locale: string, format: 'json' | 'csv' = 'json'): Promise<string> {
+    try {
+      const translations = await this.loadTranslations(locale);
+      
+      if (format === 'csv') {
+        return this.convertToCSV(translations);
+      }
+      
+      return JSON.stringify(translations, null, 2);
+    } catch (error) {
+      this.logger.error(`Error exporting translations for ${locale}:`, error);
+      throw error;
+    }
+  }
+
+  async importTranslations(locale: string, data: string, format: 'json' | 'csv' = 'json'): Promise<void> {
+    try {
+      let translations: Record<string, any>;
+      
+      if (format === 'csv') {
+        translations = this.convertFromCSV(data);
+      } else {
+        translations = JSON.parse(data);
+      }
+      
+      const filePath = join(this.translationsPath, `${locale}.json`);
+      await fs.writeFile(filePath, JSON.stringify(translations, null, 2));
+      
+      this.logger.log(`Imported translations for locale ${locale}`);
+    } catch (error) {
+      this.logger.error(`Error importing translations:`, error);
+      throw error;
+    }
+  }
+
+  private async loadTranslations(locale: string): Promise<Record<string, any>> {
+    try {
+      const filePath = join(this.translationsPath, `${locale}.json`);
+      const content = await fs.readFile(filePath, 'utf8');
+      return JSON.parse(content);
+    } catch (error) {
+      if (error.code === 'ENOENT') {
+        return {};
+      }
+      throw error;
+    }
+  }
+
+  private flattenKeys(obj: Record<string, any>, prefix = ''): string[] {
+    const keys: string[] = [];
+    
+    for (const [key, value] of Object.entries(obj)) {
+      const fullKey = prefix ? `${prefix}.${key}` : key;
+      
+      if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        keys.push(...this.flattenKeys(value, fullKey));
+      } else {
+        keys.push(fullKey);
+      }
+    }
+    
+    return keys;
+  }
+
+  private setNestedValue(obj: Record<string, any>, key: string, value: any): void {
+    const keys = key.split('.');
+    let current = obj;
+    
+    for (let i = 0; i < keys.length - 1; i++) {
+      if (!(keys[i] in current)) {
+        current[keys[i]] = {};
+      }
+      current = current[keys[i]];
+    }
+    
+    current[keys[keys.length - 1]] = value;
+  }
+
+  private deleteNestedValue(obj: Record<string, any>, key: string): void {
+    const keys = key.split('.');
+    let current = obj;
+    
+    for (let i = 0; i < keys.length - 1; i++) {
+      if (!(keys[i] in current)) {
+        return;
+      }
+      current = current[keys[i]];
+    }
+    
+    delete current[keys[keys.length - 1]];
+  }
+
+  private convertToCSV(translations: Record<string, any>): string {
+    const flatTranslations = this.flattenTranslations(translations);
+    const rows = ['key,value'];
+    
+    for (const [key, value] of Object.entries(flatTranslations)) {
+      const escapedValue = String(value).replace(/"/g, '""');
+      rows.push(`"${key}","${escapedValue}"`);
+    }
+    
+    return rows.join('\n');
+  }
+
+  private convertFromCSV(csv: string): Record<string, any> {
+    const lines = csv.split('\n').slice(1); // Skip header
+    const translations = {};
+    
+    for (const line of lines) {
+      const [key, value] = line.split(',').map(field => field.replace(/^"|"$/g, '').replace(/""/g, '"'));
+      this.setNestedValue(translations, key, value);
+    }
+    
+    return translations;
+  }
+
+  private flattenTranslations(obj: Record<string, any>, prefix = ''): Record<string, string> {
+    const result: Record<string, string> = {};
+    
+    for (const [key, value] of Object.entries(obj)) {
+      const fullKey = prefix ? `${prefix}.${key}` : key;
+      
+      if (typeof value === 'object' && value !== null && !Array.isArray(value)) {
+        Object.assign(result, this.flattenTranslations(value, fullKey));
+      } else {
+        result[fullKey] = String(value);
+      }
+    }
+    
+    return result;
+  }
+}

--- a/src/languageSystem/services/translation.service.ts
+++ b/src/languageSystem/services/translation.service.ts
@@ -1,0 +1,78 @@
+import { Injectable } from '@nestjs/common';
+import { I18nService, I18nContext } from 'nestjs-i18n';
+
+export interface TranslationOptions {
+  args?: Record<string, any>;
+  count?: number;
+  locale?: string;
+}
+
+@Injectable()
+export class TranslationService {
+  constructor(private readonly i18n: I18nService) {}
+
+  translate(key: string, options?: TranslationOptions): string {
+    const locale = options?.locale || I18nContext.current()?.lang || 'en';
+    
+    if (options?.count !== undefined) {
+      return this.translateWithPluralization(key, options.count, locale, options.args);
+    }
+
+    return this.i18n.translate(key, {
+      lang: locale,
+      args: options?.args,
+    });
+  }
+
+  private translateWithPluralization(
+    key: string,
+    count: number,
+    locale: string,
+    args?: Record<string, any>
+  ): string {
+    const pluralKey = this.getPluralKey(key, count, locale);
+    return this.i18n.translate(pluralKey, {
+      lang: locale,
+      args: { ...args, count },
+    });
+  }
+
+  private getPluralKey(key: string, count: number, locale: string): string {
+    const rules = this.getPluralRules(locale);
+    const rule = rules(count);
+    
+    return `${key}.${rule}`;
+  }
+
+  private getPluralRules(locale: string): (count: number) => string {
+    const intl = new Intl.PluralRules(locale);
+    return (count: number) => intl.select(count);
+  }
+
+  getSupportedLocales(): string[] {
+    return ['en', 'es', 'fr', 'de', 'ar', 'zh', 'ja'];
+  }
+
+  isRTLLanguage(locale: string): boolean {
+    const rtlLanguages = ['ar', 'he', 'fa', 'ur'];
+    return rtlLanguages.includes(locale.toLowerCase());
+  }
+
+  formatNumber(value: number, locale?: string): string {
+    const currentLocale = locale || I18nContext.current()?.lang || 'en';
+    return new Intl.NumberFormat(currentLocale).format(value);
+  }
+
+  formatDate(date: Date, locale?: string, options?: Intl.DateTimeFormatOptions): string {
+    const currentLocale = locale || I18nContext.current()?.lang || 'en';
+    return new Intl.DateTimeFormat(currentLocale, options).format(date);
+  }
+
+  formatCurrency(amount: number, currency: string, locale?: string): string {
+    const currentLocale = locale || I18nContext.current()?.lang || 'en';
+    return new Intl.NumberFormat(currentLocale, {
+      style: 'currency',
+      currency,
+    }).format(amount);
+  }
+}

--- a/src/languageSystem/translations/en.json
+++ b/src/languageSystem/translations/en.json
@@ -1,0 +1,85 @@
+{
+  "common": {
+    "hello": "Hello",
+    "goodbye": "Goodbye",
+    "welcome": "Welcome",
+    "loading": "Loading...",
+    "error": "An error occurred",
+    "success": "Success",
+    "cancel": "Cancel",
+    "save": "Save",
+    "delete": "Delete",
+    "edit": "Edit",
+    "create": "Create",
+    "back": "Back",
+    "next": "Next",
+    "previous": "Previous",
+    "search": "Search",
+    "filter": "Filter",
+    "sort": "Sort",
+    "export": "Export",
+    "import": "Import"
+  },
+  "navigation": {
+    "home": "Home",
+    "about": "About",
+    "contact": "Contact",
+    "services": "Services",
+    "products": "Products",
+    "profile": "Profile",
+    "settings": "Settings",
+    "logout": "Logout"
+  },
+  "forms": {
+    "email": "Email",
+    "password": "Password",
+    "confirmPassword": "Confirm Password",
+    "firstName": "First Name",
+    "lastName": "Last Name",
+    "phone": "Phone Number",
+    "address": "Address",
+    "city": "City",
+    "country": "Country",
+    "zipCode": "ZIP Code",
+    "submit": "Submit",
+    "reset": "Reset"
+  },
+  "validation": {
+    "required": "This field is required",
+    "email": "Please enter a valid email address",
+    "minLength": "Minimum length is {{min}} characters",
+    "maxLength": "Maximum length is {{max}} characters",
+    "min": "Minimum value is {{min}}",
+    "max": "Maximum value is {{max}}",
+    "pattern": "Invalid format",
+    "failed": "Validation failed"
+  },
+  "messages": {
+    "item": {
+      "zero": "No items",
+      "one": "{{count}} item",
+      "other": "{{count}} items"
+    },
+    "notification": {
+      "zero": "No notifications",
+      "one": "{{count}} notification",
+      "other": "{{count}} notifications"
+    }
+  },
+  "errors": {
+    "notFound": "Not found",
+    "unauthorized": "Unauthorized",
+    "forbidden": "Forbidden",
+    "serverError": "Internal server error",
+    "networkError": "Network error",
+    "timeout": "Request timeout"
+  },
+  "date": {
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "tomorrow": "Tomorrow",
+    "thisWeek": "This week",
+    "thisMonth": "This month",
+    "thisYear": "This year"
+  }
+}

--- a/src/languageSystem/translations/es.json
+++ b/src/languageSystem/translations/es.json
@@ -1,0 +1,85 @@
+{
+  "common": {
+    "hello": "Hola",
+    "goodbye": "Adiós",
+    "welcome": "Bienvenido",
+    "loading": "Cargando...",
+    "error": "Ha ocurrido un error",
+    "success": "Éxito",
+    "cancel": "Cancelar",
+    "save": "Guardar",
+    "delete": "Eliminar",
+    "edit": "Editar",
+    "create": "Crear",
+    "back": "Atrás",
+    "next": "Siguiente",
+    "previous": "Anterior",
+    "search": "Buscar",
+    "filter": "Filtrar",
+    "sort": "Ordenar",
+    "export": "Exportar",
+    "import": "Importar"
+  },
+  "navigation": {
+    "home": "Inicio",
+    "about": "Acerca de",
+    "contact": "Contacto",
+    "services": "Servicios",
+    "products": "Productos",
+    "profile": "Perfil",
+    "settings": "Configuración",
+    "logout": "Cerrar sesión"
+  },
+  "forms": {
+    "email": "Correo electrónico",
+    "password": "Contraseña",
+    "confirmPassword": "Confirmar contraseña",
+    "firstName": "Nombre",
+    "lastName": "Apellido",
+    "phone": "Teléfono",
+    "address": "Dirección",
+    "city": "Ciudad",
+    "country": "País",
+    "zipCode": "Código postal",
+    "submit": "Enviar",
+    "reset": "Restablecer"
+  },
+  "validation": {
+    "required": "Este campo es obligatorio",
+    "email": "Por favor ingrese un email válido",
+    "minLength": "La longitud mínima es {{min}} caracteres",
+    "maxLength": "La longitud máxima es {{max}} caracteres",
+    "min": "El valor mínimo es {{min}}",
+    "max": "El valor máximo es {{max}}",
+    "pattern": "Formato inválido",
+    "failed": "Validación fallida"
+  },
+  "messages": {
+    "item": {
+      "zero": "Sin elementos",
+      "one": "{{count}} elemento",
+      "other": "{{count}} elementos"
+    },
+    "notification": {
+      "zero": "Sin notificaciones",
+      "one": "{{count}} notificación",
+      "other": "{{count}} notificaciones"
+    }
+  },
+  "errors": {
+    "notFound": "No encontrado",
+    "unauthorized": "No autorizado",
+    "forbidden": "Prohibido",
+    "serverError": "Error interno del servidor",
+    "networkError": "Error de red",
+    "timeout": "Tiempo de espera agotado"
+  },
+  "date": {
+    "today": "Hoy",
+    "yesterday": "Ayer",
+    "tomorrow": "Mañana",
+    "thisWeek": "Esta semana",
+    "thisMonth": "Este mes",
+    "thisYear": "Este año"
+  }
+}


### PR DESCRIPTION
Set up i18n module

Install and configure an internationalization library (e.g. i18next, next-i18next, etc.).

Create translation files

Build language JSON files (e.g., en.json, fr.json) to store key-value translation pairs.

Implement locale detection and selection

Automatically detect user's language and allow manual switching.

Build translation service

Create a utility or context to fetch and apply translations across components.

Create translation management system

Design a way to manage, update, and add translations easily (could be an admin tool or structured file system).

Implement pluralization support

Handle different word forms based on counts (e.g., 1 item vs 3 items).

Set up RTL language support

Enable support for right-to-left languages like Arabic or Hebrew by adjusting layout and direction styles.

Close #21 