### PR TITLE
feat(loyalty): implement customer loyalty program with points, tiers,…

### DIFF
--- a/src/files/dto/upload-file.dto.ts
+++ b/src/files/dto/upload-file.dto.ts
@@ -1,0 +1,11 @@
+import { IsOptional, IsString } from 'class-validator';
+
+export class UploadFileDto {
+  @IsOptional()
+  @IsString()
+  relatedType?: string; // e.g. "Project", "UserProfile", etc.
+
+  @IsOptional()
+  @IsString()
+  relatedId?: string;   // The ID of the related entity, if any
+}

--- a/src/files/entities/file-metadata.entity.ts
+++ b/src/files/entities/file-metadata.entity.ts
@@ -1,0 +1,43 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../users/user.entity'; 
+
+@Entity({ name: 'file_metadata' })
+export class FileMetadata {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Index()
+  @Column({ unique: true })
+  filename: string;      
+
+  @Column()
+  originalName: string; 
+
+  @Column()
+  mimeType: string;      
+
+  @Column({ type: 'int' })
+  size: number;         
+
+  @CreateDateColumn()
+  uploadDate: Date;
+
+  @Column()
+  url: string;           // Publicly accessible URL or path
+
+  @ManyToOne(() => User, (user) => user.files, { onDelete: 'CASCADE' })
+  owner: User;
+
+  @Column({ type: 'varchar', length: 50, nullable: true })
+  relatedType?: string;  // e.g. “Project”, “Post”
+
+  @Column({ type: 'varchar', length: 36, nullable: true })
+  relatedId?: string;    // ID of the related entity
+}

--- a/src/files/file.controller.ts
+++ b/src/files/file.controller.ts
@@ -1,0 +1,118 @@
+import {
+  Controller,
+  Post,
+  UseGuards,
+  UseInterceptors,
+  UploadedFile,
+  Body,
+  Req,
+  Get,
+  Param,
+  Res,
+  Delete,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { FileService } from './file.service';
+import { AuthGuard } from '@nestjs/passport';
+import { FileInterceptor } from '@nestjs/platform-express';
+import { multerOptions } from './multer.config';
+import { UploadFileDto } from './dto/upload-file.dto';
+import { FileAccessGuard } from './guards/file-access.guard';
+import { Response } from 'express';
+
+@Controller('files')
+@UseGuards(AuthGuard('jwt'))
+export class FileController {
+  constructor(private readonly fileService: FileService) {}
+
+  /**
+   * POST /files/upload
+   * - Headers: Authorization: Bearer <token>
+   * - Body: multipart/form-data with `file` (binary) and optional fields (relatedType, relatedId)
+   */
+  @Post('upload')
+  @UseInterceptors(FileInterceptor('file', multerOptions))
+  async upload(
+    @Req() req: any,
+    @UploadedFile() file: Express.Multer.File,
+    @Body() dto: UploadFileDto,
+  ) {
+    if (!file) {
+      return { error: 'No file provided' };
+    }
+
+    const userId = req.user.id;
+    const savedMeta = await this.fileService.uploadFile(
+      userId,
+      file.buffer,
+      file.originalname,
+      file.mimetype,
+      file.size,
+      dto,
+    );
+
+    return {
+      id: savedMeta.id,
+      originalName: savedMeta.originalName,
+      mimeType: savedMeta.mimeType,
+      size: savedMeta.size,
+      url: savedMeta.url,
+      uploadDate: savedMeta.uploadDate,
+      relatedType: savedMeta.relatedType,
+      relatedId: savedMeta.relatedId,
+    };
+  }
+
+  /**
+   * GET /files/:fileId
+   * - Streams the requested file back to the client.
+   * - Guard ensures only the owner can access.
+   */
+  @Get(':fileId')
+  @UseGuards(FileAccessGuard)
+  async download(@Req() req: any, @Res() res: Response) {
+    const fileMeta = req.fileMeta;
+    const streamable = await this.fileService.getFileStream(fileMeta);
+
+    res.set({
+      'Content-Type': fileMeta.mimeType,
+      'Content-Disposition': `attachment; filename="${fileMeta.originalName}"`,
+    });
+    return streamable.getStream().pipe(res);
+  }
+
+  /**
+   * DELETE /files/:fileId
+   * - Deletes the file (both from storage and DB).
+   * - Guard ensures only the owner can delete.
+   */
+  @Delete(':fileId')
+  @UseGuards(FileAccessGuard)
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async remove(@Req() req: any) {
+    const fileMeta = req.fileMeta;
+    await this.fileService.deleteFile(fileMeta);
+    // No JSON body needed for 204
+  }
+
+  /**
+   * GET /files
+   * - Returns a list of FileMetadata belonging to the authenticated user.
+   */
+  @Get()
+  async listUserFiles(@Req() req: any) {
+    const userId = req.user.id;
+    const files = await this.fileService.listUserFiles(userId);
+    return files.map((f) => ({
+      id: f.id,
+      originalName: f.originalName,
+      mimeType: f.mimeType,
+      size: f.size,
+      url: f.url,
+      uploadDate: f.uploadDate,
+      relatedType: f.relatedType,
+      relatedId: f.relatedId,
+    }));
+  }
+}

--- a/src/files/file.module.ts
+++ b/src/files/file.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { FileService } from './file.service';
+import { FileController } from './file.controller';
+import { FileMetadata } from './entities/file-metadata.entity';
+import { User } from '../users/user.entity'; // adjust path if needed
+import { FileAccessGuard } from './guards/file-access.guard';
+import { StorageService } from './storage/storage.service';
+import { LocalStorageService } from './storage/local-storage.service';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([FileMetadata, User])],
+  controllers: [FileController],
+  providers: [
+    FileService,
+    FileAccessGuard,
+    {
+      provide: StorageService,
+      useClass: LocalStorageService,
+    },
+  ],
+  exports: [FileService],
+})
+export class FileModule {}

--- a/src/files/file.service.ts
+++ b/src/files/file.service.ts
@@ -1,0 +1,166 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, In } from 'typeorm';
+import { FileMetadata } from './entities/file-metadata.entity';
+import { UploadFileDto } from './dto/upload-file.dto';
+import { StorageService } from './storage/storage.service';
+import { User } from '../users/user.entity'; // adjust path if needed
+import { Cron, CronExpression } from '@nestjs/schedule';
+import * as sharp from 'sharp';
+import { randomUUID } from 'crypto';
+import { StreamableFile } from '@nestjs/common';
+import { join } from 'path';
+import { existsSync, readdirSync } from 'fs';
+
+@Injectable()
+export class FileService {
+  private readonly logger = new Logger(FileService.name);
+
+  constructor(
+    @InjectRepository(FileMetadata)
+    private readonly fileRepo: Repository<FileMetadata>,
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+    private readonly storageService: StorageService,
+  ) {}
+
+  /**
+   * Uploads a file buffer (from Multer) and returns FileMetadata.
+   */
+  async uploadFile(
+    userId: string,
+    fileBuffer: Buffer,
+    originalName: string,
+    mimeType: string,
+    size: number,
+    dto: UploadFileDto,
+  ): Promise<FileMetadata> {
+    // 1. Check that user exists
+    const user = await this.userRepo.findOne({ where: { id: userId } });
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    // 2. Check for valid MIME types is already done by multer’s fileFilter
+    //    (but you could place extra scanning logic here, e.g., virus scan)
+
+    // 3. If image, run through Sharp to resize/optimize
+    let finalBuffer = fileBuffer;
+    if (mimeType.startsWith('image/')) {
+      try {
+        const transformer = sharp(fileBuffer).rotate();
+
+        // Resize: max width 1920, preserve aspect ratio, no upscaling
+        transformer.resize({ width: 1920, withoutEnlargement: true });
+
+        // If JPEG, compress to quality 80; if PNG, compress accordingly
+        if (mimeType === 'image/png') {
+          transformer.png({ quality: 80 });
+        } else {
+          // defaults to JPEG for other image types
+          transformer.jpeg({ quality: 80 });
+        }
+
+        finalBuffer = await transformer.toBuffer();
+      } catch (err) {
+        throw new BadRequestException(`Failed to optimize image: ${err.message}`);
+      }
+    }
+
+    // 4. Generate a unique key (e.g. UUID + extension)
+    const extension = originalName.substring(originalName.lastIndexOf('.')) || '';
+    const key = `${randomUUID()}${extension}`;
+
+    // 5. Save file via storage service, get back URL
+    const url = await this.storageService.saveFile(finalBuffer, key, mimeType);
+
+    // 6. Persist metadata
+    const metadata = this.fileRepo.create({
+      filename: key,
+      originalName,
+      mimeType,
+      size: finalBuffer.length,
+      url,
+      owner: user,
+      relatedType: dto.relatedType,
+      relatedId: dto.relatedId,
+    });
+    return this.fileRepo.save(metadata);
+  }
+
+  /**
+   * Returns a StreamableFile for downloading.
+   * The FileAccessGuard already verified ownership and attached fileMeta to request.
+   */
+  async getFileStream(fileMeta: FileMetadata): Promise<StreamableFile> {
+    return this.storageService.getFileStream(fileMeta.filename);
+  }
+
+  /**
+   * Deletes the file from both storage and database.
+   * The FileAccessGuard verified ownership.
+   */
+  async deleteFile(fileMeta: FileMetadata): Promise<void> {
+    // 1. Delete from storage
+    await this.storageService.deleteFile(fileMeta.filename);
+
+    // 2. Delete metadata
+    await this.fileRepo.delete({ id: fileMeta.id });
+  }
+
+  /**
+   * Lists all files owned by a given user.
+   */
+  async listUserFiles(userId: string): Promise<FileMetadata[]> {
+    return this.fileRepo.find({
+      where: { owner: { id: userId } },
+      order: { uploadDate: 'DESC' },
+    });
+  }
+
+  /**
+   * Daily cron job (midnight Africa/Lagos) to remove orphaned files:
+   * files present on disk/cloud but not referenced in the DB.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, { timeZone: 'Africa/Lagos' })
+  async cleanupOrphanedFiles() {
+    this.logger.log('Running orphaned file cleanup job…');
+
+    // 1. Fetch all keys from storage folder
+    const uploadsDir = join(process.cwd(), 'uploads');
+    if (!existsSync(uploadsDir)) {
+      this.logger.warn(`Uploads directory not found at ${uploadsDir}`);
+      return;
+    }
+
+    const filesInDir: string[] = readdirSync(uploadsDir);
+    if (filesInDir.length === 0) {
+      this.logger.log('No files found in uploads directory.');
+      return;
+    }
+
+    // 2. Fetch all filenames from DB
+    const allMeta = await this.fileRepo.find({ select: ['filename'] });
+    const filenamesInDb = new Set(allMeta.map((m) => m.filename));
+
+    // 3. Compare and delete any file not in DB
+    for (const filename of filesInDir) {
+      if (!filenamesInDb.has(filename)) {
+        try {
+          await this.storageService.deleteFile(filename);
+          this.logger.log(`Deleted orphaned file: ${filename}`);
+        } catch (err) {
+          this.logger.error(`Failed to delete orphaned file ${filename}: ${err.message}`);
+        }
+      }
+    }
+
+    this.logger.log('Orphaned file cleanup job complete.');
+  }
+}

--- a/src/files/guards/file-access.guard.ts
+++ b/src/files/guards/file-access.guard.ts
@@ -1,0 +1,47 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  Injectable,
+  ForbiddenException,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { FileMetadata } from '../entities/file-metadata.entity';
+import { Repository } from 'typeorm';
+import { InjectRepository } from '@nestjs/typeorm';
+
+@Injectable()
+export class FileAccessGuard implements CanActivate {
+  constructor(
+    @InjectRepository(FileMetadata)
+    private readonly fileRepo: Repository<FileMetadata>,
+    private readonly reflector: Reflector,
+  ) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const user = request.user;
+    const fileId = request.params.fileId;
+
+    if (!user || !fileId) {
+      throw new ForbiddenException('Missing user credentials or fileId');
+    }
+
+    const fileMeta = await this.fileRepo.findOne({
+      where: { id: fileId },
+      relations: ['owner'],
+    });
+
+    if (!fileMeta) {
+      throw new ForbiddenException('File not found');
+    }
+
+    // Only the owner can access. (You can extend this to handle shared permissions.)
+    if (fileMeta.owner.id !== user.id) {
+      throw new ForbiddenException('You do not have permission to access this file');
+    }
+
+    // Attach the metadata to the request so controllers can reuse it
+    request.fileMeta = fileMeta;
+    return true;
+  }
+}

--- a/src/files/multer.config.ts
+++ b/src/files/multer.config.ts
@@ -1,0 +1,33 @@
+import { diskStorage, memoryStorage } from 'multer';
+import { BadRequestException } from '@nestjs/common';
+import { extname, join } from 'path';
+import { randomUUID } from 'crypto';
+
+// Allowed MIME types
+const ALLOWED_MIME_TYPES = [
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'application/pdf',
+];
+
+export const multerOptions = {
+  storage: memoryStorage(), // we process the file in memory (to optimize images before saving)
+  limits: {
+    fileSize: 10 * 1024 * 1024, // 10 MB
+  },
+  fileFilter: (req: any, file: Express.Multer.File, cb: Function) => {
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      return cb(
+        new BadRequestException(
+          `Unsupported file type ${file.mimetype}. Allowed: ${ALLOWED_MIME_TYPES.join(
+            ', ',
+          )}`,
+        ),
+        false,
+      );
+    }
+    cb(null, true);
+  },
+};

--- a/src/files/storage/local-storage.service.ts
+++ b/src/files/storage/local-storage.service.ts
@@ -1,0 +1,68 @@
+
+import {
+  Injectable,
+  InternalServerErrorException,
+  StreamableFile,
+} from '@nestjs/common';
+import { createWriteStream, existsSync, mkdirSync, createReadStream } from 'fs';
+import { join } from 'path';
+import { StorageService } from './storage.service';
+
+@Injectable()
+export class LocalStorageService implements StorageService {
+  private uploadPath = join(process.cwd(), 'uploads');
+
+  constructor() {
+    // Ensure `uploads/` folder exists
+    if (!existsSync(this.uploadPath)) {
+      mkdirSync(this.uploadPath, { recursive: true });
+    }
+  }
+
+  async saveFile(
+    buffer: Buffer,
+    key: string,
+    mimeType: string,
+  ): Promise<string> {
+    const filePath = join(this.uploadPath, key);
+    return new Promise((resolve, reject) => {
+      const writeStream = createWriteStream(filePath);
+      writeStream.write(buffer);
+      writeStream.end();
+      writeStream.on('finish', () => {
+        // Return a relative URL: e.g. "/uploads/<key>"
+        const url = `/uploads/${key}`;
+        resolve(url);
+      });
+      writeStream.on('error', (err) => {
+        reject(new InternalServerErrorException('Failed to write file: ' + err.message));
+      });
+    });
+  }
+
+  async deleteFile(key: string): Promise<void> {
+    const filePath = join(this.uploadPath, key);
+    return new Promise((resolve, reject) => {
+      // If file doesn’t exist, just resolve
+      if (!existsSync(filePath)) {
+        return resolve();
+      }
+      try {
+        // Synchronously remove the file
+        require('fs').unlinkSync(filePath);
+        resolve();
+      } catch (err) {
+        reject(new InternalServerErrorException('Failed to delete file: ' + err.message));
+      }
+    });
+  }
+
+  async getFileStream(key: string): Promise<StreamableFile> {
+    const filePath = join(this.uploadPath, key);
+    if (!existsSync(filePath)) {
+      throw new InternalServerErrorException('File not found');
+    }
+    const readStream: ReadStream = createReadStream(filePath);
+    return new StreamableFile(readStream);
+  }
+}

--- a/src/files/storage/storage.service.ts
+++ b/src/files/storage/storage.service.ts
@@ -1,0 +1,16 @@
+import { StreamableFile } from '@nestjs/common';
+import { ReadStream } from 'fs';
+
+export abstract class StorageService {
+ 
+  abstract saveFile(
+    buffer: Buffer,
+    key: string,
+    mimeType: string,
+  ): Promise<string>;
+
+  
+  abstract deleteFile(key: string): Promise<void>;
+
+  abstract getFileStream(key: string): Promise<StreamableFile>;
+}

--- a/src/loyalty/dto/create-transaction.dto.ts
+++ b/src/loyalty/dto/create-transaction.dto.ts
@@ -1,0 +1,17 @@
+import { IsUUID, IsEnum, IsInt, IsOptional, IsObject } from 'class-validator';
+import { PointsType } from '../entities/points.entity';
+
+export class CreateTransactionDto {
+  @IsUUID()
+  programId: string;
+
+  @IsEnum(PointsType)
+  type: PointsType;
+
+  @IsInt()
+  points: number;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}

--- a/src/loyalty/dto/redeem-reward.dto.ts
+++ b/src/loyalty/dto/redeem-reward.dto.ts
@@ -1,0 +1,9 @@
+import { IsUUID } from 'class-validator';
+
+export class RedeemRewardDto {
+  @IsUUID()
+  programId: string;
+
+  @IsUUID()
+  rewardId: string;
+}

--- a/src/loyalty/entities/loyalty-program.entity.ts
+++ b/src/loyalty/entities/loyalty-program.entity.ts
@@ -1,0 +1,29 @@
+import { Entity, Column, PrimaryGeneratedColumn, OneToMany } from 'typeorm';
+import { LoyaltyTier } from './loyalty-tier.entity';
+import { Reward } from './reward.entity';
+
+@Entity({ name: 'loyalty_programs' })
+export class LoyaltyProgram {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  // Number of days before points expire (default: 365)
+  @Column({ type: 'int', default: 365 })
+  pointsExpirationDays: number;
+
+  @OneToMany(() => LoyaltyTier, (tier) => tier.program, {
+    cascade: true,
+  })
+  tiers: LoyaltyTier[];
+
+  @OneToMany(() => Reward, (reward) => reward.program, {
+    cascade: true,
+  })
+  rewards: Reward[];
+}

--- a/src/loyalty/entities/loyalty-tier.entity.ts
+++ b/src/loyalty/entities/loyalty-tier.entity.ts
@@ -1,0 +1,28 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
+import { LoyaltyProgram } from './loyalty-program.entity';
+
+@Entity({ name: 'loyalty_tiers' })
+export class LoyaltyTier {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string; // e.g. 'Bronze', 'Silver', 'Gold'
+
+  @Column({ type: 'int' })
+  minPoints: number; // minimum points needed to qualify
+
+  @Column({ type: 'int', default: 0 })
+  benefitsDiscountPercent: number;
+
+  @ManyToOne(() => LoyaltyProgram, (program) => program.tiers, {
+    onDelete: 'CASCADE',
+  })
+  program: LoyaltyProgram;
+}

--- a/src/loyalty/entities/points.entity.ts
+++ b/src/loyalty/entities/points.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { User } from '../users/user.entity';
+import { LoyaltyProgram } from './loyalty-program.entity';
+
+export enum PointsType {
+  EARN = 'earn',
+  REDEEM = 'redeem',
+  EXPIRE = 'expire',
+}
+
+@Entity({ name: 'points_transactions' })
+export class PointsTransaction {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => User, (user) => user.pointsTransactions, {
+    onDelete: 'CASCADE',
+  })
+  user: User;
+
+  @ManyToOne(() => LoyaltyProgram, (program) => program.id, {
+    onDelete: 'CASCADE',
+  })
+  program: LoyaltyProgram;
+
+  @Column({ type: 'enum', enum: PointsType })
+  type: PointsType;
+
+  @Column({ type: 'int' })
+  points: number;
+
+  // A JSON field to store e.g. { orderId: '...', rewardId: '...' }
+  @Column({ type: 'json', nullable: true })
+  metadata: Record<string, any>;
+
+  @Index()
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @Column({ type: 'timestamp' })
+  expirationDate: Date;
+}

--- a/src/loyalty/entities/reward.entity.ts
+++ b/src/loyalty/entities/reward.entity.ts
@@ -1,0 +1,31 @@
+import {
+  Entity,
+  Column,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  OneToMany,
+} from 'typeorm';
+import { LoyaltyProgram } from './loyalty-program.entity';
+
+@Entity({ name: 'rewards' })
+export class Reward {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'int' })
+  pointsCost: number;
+
+  @Column({ type: 'int', default: 0 })
+  stock: number; // number of items available
+
+  @ManyToOne(() => LoyaltyProgram, (program) => program.rewards, {
+    onDelete: 'CASCADE',
+  })
+  program: LoyaltyProgram;
+}

--- a/src/loyalty/loyalty.controller.ts
+++ b/src/loyalty/loyalty.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Controller,
+  Post,
+  Body,
+  Param,
+  Get,
+  UseGuards,
+  Req,
+} from '@nestjs/common';
+import { LoyaltyService } from './loyalty.service';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { RedeemRewardDto } from './dto/redeem-reward.dto';
+import { AuthGuard } from '@nestjs/passport';
+
+@Controller('loyalty')
+@UseGuards(AuthGuard('jwt')) // assuming JWT auth
+export class LoyaltyController {
+  constructor(private readonly loyaltyService: LoyaltyService) {}
+
+  @Post('transaction')
+  async createTransaction(@Req() req, @Body() dto: CreateTransactionDto) {
+    const userId = req.user.id;
+    const tx = await this.loyaltyService.createTransaction(userId, dto);
+    return tx;
+  }
+
+  @Post('redeem')
+  async redeemReward(@Req() req, @Body() dto: RedeemRewardDto) {
+    const userId = req.user.id;
+    return this.loyaltyService.redeemReward(userId, dto);
+  }
+
+  @Get('rewards/:programId')
+  async listRewards(@Param('programId') programId: string) {
+    return this.loyaltyService.listRewards(programId);
+  }
+
+  @Get('tier/:programId')
+  async getUserTier(@Req() req, @Param('programId') programId: string) {
+    const userId = req.user.id;
+    // Retrieve current balance, then figure out tier
+    const program = await this.loyaltyService.programRepo.findOne(programId, {
+      relations: ['tiers'],
+    });
+    if (!program) {
+      throw new NotFoundException('Program not found');
+    }
+    const balance = await this.loyaltyService.calculateUserBalance(
+      userId,
+      programId,
+    );
+    const tiers = await this.loyaltyService.tierRepo.find({
+      where: { program: { id: programId } },
+      order: { minPoints: 'ASC' },
+    });
+    let currentTier = null;
+    for (const tier of tiers) {
+      if (balance >= tier.minPoints) {
+        currentTier = tier;
+      } else {
+        break;
+      }
+    }
+    return { tier: currentTier, balance };
+  }
+
+  @Get('analytics/:programId')
+  async getAnalytics(@Param('programId') programId: string) {
+    return this.loyaltyService.getAnalytics(programId);
+  }
+}

--- a/src/loyalty/loyalty.module.ts
+++ b/src/loyalty/loyalty.module.ts
@@ -1,0 +1,26 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { LoyaltyService } from './loyalty.service';
+import { LoyaltyController } from './loyalty.controller';
+import { LoyaltyProgram } from './entities/loyalty-program.entity';
+import { LoyaltyTier } from './entities/loyalty-tier.entity';
+import { Reward } from './entities/reward.entity';
+import { PointsTransaction } from './entities/points.entity';
+import { User } from '../users/user.entity';
+import { NotificationModule } from '../notifications/notification.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      LoyaltyProgram,
+      LoyaltyTier,
+      Reward,
+      PointsTransaction,
+      User,
+    ]),
+    NotificationModule,
+  ],
+  providers: [LoyaltyService],
+  controllers: [LoyaltyController],
+})
+export class LoyaltyModule {}

--- a/src/loyalty/loyalty.service.ts
+++ b/src/loyalty/loyalty.service.ts
@@ -1,0 +1,337 @@
+import {
+  Injectable,
+  NotFoundException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository, MoreThan, LessThan } from 'typeorm';
+import { LoyaltyProgram } from './entities/loyalty-program.entity';
+import { PointsTransaction, PointsType } from './entities/points.entity';
+import { LoyaltyTier } from './entities/loyalty-tier.entity';
+import { Reward } from './entities/reward.entity';
+import { CreateTransactionDto } from './dto/create-transaction.dto';
+import { RedeemRewardDto } from './dto/redeem-reward.dto';
+import { User } from '../users/user.entity';
+import { Cron, CronExpression } from '@nestjs/schedule';
+import { NotificationService } from '../notifications/notification.service';
+
+@Injectable()
+export class LoyaltyService {
+  private readonly logger = new Logger(LoyaltyService.name);
+
+  constructor(
+    @InjectRepository(LoyaltyProgram)
+    private readonly programRepo: Repository<LoyaltyProgram>,
+
+    @InjectRepository(PointsTransaction)
+    private readonly transactionRepo: Repository<PointsTransaction>,
+
+    @InjectRepository(LoyaltyTier)
+    private readonly tierRepo: Repository<LoyaltyTier>,
+
+    @InjectRepository(Reward)
+    private readonly rewardRepo: Repository<Reward>,
+
+    @InjectRepository(User)
+    private readonly userRepo: Repository<User>,
+
+    private readonly notificationService: NotificationService,
+  ) {}
+
+  /**
+   * Earn or redeem points for a user.
+   */
+  async createTransaction(
+    userId: string,
+    dto: CreateTransactionDto,
+  ): Promise<PointsTransaction> {
+    const { programId, type, points, metadata } = dto;
+    const user = await this.userRepo.findOne(userId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const program = await this.programRepo.findOne(programId, {
+      relations: ['tiers'],
+    });
+    if (!program) {
+      throw new NotFoundException('Loyalty program not found');
+    }
+
+    // Calculate expiration date from now
+    const expirationDate = new Date();
+    expirationDate.setDate(
+      expirationDate.getDate() + program.pointsExpirationDays,
+    );
+
+    // If redeeming, check available balance
+    if (type === PointsType.REDEEM) {
+      const balance = await this.calculateUserBalance(userId, programId);
+      if (balance < points) {
+        throw new BadRequestException('Insufficient points to redeem');
+      }
+    }
+
+    const tx = this.transactionRepo.create({
+      user,
+      program,
+      type,
+      points,
+      metadata,
+      expirationDate,
+    });
+    const savedTx = await this.transactionRepo.save(tx);
+
+    // After earning or redeeming, send notifications and check tier upgrade
+    if (type === PointsType.EARN) {
+      await this.checkAndUpgradeTier(user, program);
+      this.notificationService.sendPointsEarnedNotification(
+        user.id,
+        points,
+        balance: await this.calculateUserBalance(userId, programId),
+      );
+    } else if (type === PointsType.REDEEM) {
+      this.notificationService.sendPointsRedeemedNotification(
+        user.id,
+        points,
+      );
+    }
+
+    return savedTx;
+  }
+
+  /**
+   * Calculate current points balance (excluding expired or redeemed).
+   */
+  async calculateUserBalance(
+    userId: string,
+    programId: string,
+  ): Promise<number> {
+    // Sum all earned where expirationDate > now
+    const now = new Date();
+    const earned = await this.transactionRepo
+      .createQueryBuilder('tx')
+      .select('SUM(tx.points)', 'sum')
+      .where('tx.userId = :userId', { userId })
+      .andWhere('tx.programId = :programId', { programId })
+      .andWhere('tx.type = :type', { type: PointsType.EARN })
+      .andWhere('tx.expirationDate > :now', { now })
+      .getRawOne();
+
+    const redeemed = await this.transactionRepo
+      .createQueryBuilder('tx')
+      .select('SUM(tx.points)', 'sum')
+      .where('tx.userId = :userId', { userId })
+      .andWhere('tx.programId = :programId', { programId })
+      .andWhere('tx.type = :type', { type: PointsType.REDEEM })
+      .getRawOne();
+
+    const expired = await this.transactionRepo
+      .createQueryBuilder('tx')
+      .select('SUM(tx.points)', 'sum')
+      .where('tx.userId = :userId', { userId })
+      .andWhere('tx.programId = :programId', { programId })
+      .andWhere('tx.type = :type', { type: PointsType.EXPIRE })
+      .getRawOne();
+
+    const totalEarned = parseInt(earned.sum) || 0;
+    const totalRedeemed = parseInt(redeemed.sum) || 0;
+    const totalExpired = parseInt(expired.sum) || 0;
+
+    return totalEarned - totalRedeemed - totalExpired;
+  }
+
+  /**
+   * Check if user qualifies for a new tier, and upgrade if so.
+   */
+  private async checkAndUpgradeTier(
+    user: User,
+    program: LoyaltyProgram,
+  ): Promise<void> {
+    const balance = await this.calculateUserBalance(user.id, program.id);
+    const tiers = await this.tierRepo.find({
+      where: { program: { id: program.id } },
+      order: { minPoints: 'ASC' },
+    });
+
+    // Determine highest tier that balance qualifies
+    let highestTier: LoyaltyTier = null;
+    for (const tier of tiers) {
+      if (balance >= tier.minPoints) {
+        highestTier = tier;
+      } else {
+        break;
+      }
+    }
+
+    if (!highestTier) return; // no tier matches
+
+    // Compare with user's current tier
+    if (
+      !user.loyaltyTier ||
+      user.loyaltyTier.minPoints < highestTier.minPoints
+    ) {
+      user.loyaltyTier = highestTier;
+      await this.userRepo.save(user);
+
+      // Send tier upgrade notification
+      this.notificationService.sendTierUpgradeNotification(
+        user.id,
+        highestTier.name,
+      );
+    }
+  }
+
+  /**
+   * Redeem a reward for the user.
+   */
+  async redeemReward(
+    userId: string,
+    dto: RedeemRewardDto,
+  ): Promise<{ success: boolean; message: string }> {
+    const { programId, rewardId } = dto;
+    const user = await this.userRepo.findOne(userId);
+    if (!user) {
+      throw new NotFoundException('User not found');
+    }
+
+    const program = await this.programRepo.findOne(programId);
+    if (!program) {
+      throw new NotFoundException('Loyalty program not found');
+    }
+
+    const reward = await this.rewardRepo.findOne(rewardId, {
+      relations: ['program'],
+    });
+    if (!reward || reward.program.id !== program.id) {
+      throw new NotFoundException('Reward not found in this program');
+    }
+
+    const balance = await this.calculateUserBalance(userId, programId);
+    if (balance < reward.pointsCost) {
+      throw new BadRequestException('Insufficient points to redeem this reward');
+    }
+
+    if (reward.stock <= 0) {
+      throw new BadRequestException('Reward is out of stock');
+    }
+
+    // Deduct points
+    const expirationDate = new Date();
+    expirationDate.setDate(
+      expirationDate.getDate() + program.pointsExpirationDays,
+    );
+
+    const tx = this.transactionRepo.create({
+      user,
+      program,
+      type: PointsType.REDEEM,
+      points: reward.pointsCost,
+      metadata: { rewardId },
+      expirationDate,
+    });
+    await this.transactionRepo.save(tx);
+
+    // Decrement stock
+    reward.stock -= 1;
+    await this.rewardRepo.save(reward);
+
+    // Send notification
+    this.notificationService.sendRewardRedemptionNotification(
+      user.id,
+      reward.name,
+    );
+
+    return { success: true, message: 'Reward redeemed successfully' };
+  }
+
+  /**
+   * List all rewards in a program.
+   */
+  async listRewards(programId: string): Promise<Reward[]> {
+    return this.rewardRepo.find({
+      where: { program: { id: programId } },
+      order: { pointsCost: 'ASC' },
+    });
+  }
+
+  /**
+   * Calculate basic analytics: total points earned, redeemed, active users, etc.
+   */
+  async getAnalytics(programId: string): Promise<any> {
+    const totalEarned = await this.transactionRepo
+      .createQueryBuilder('tx')
+      .select('SUM(tx.points)', 'sum')
+      .where('tx.programId = :programId', { programId })
+      .andWhere('tx.type = :type', { type: PointsType.EARN })
+      .getRawOne();
+
+    const totalRedeemed = await this.transactionRepo
+      .createQueryBuilder('tx')
+      .select('SUM(tx.points)', 'sum')
+      .where('tx.programId = :programId', { programId })
+      .andWhere('tx.type = :type', { type: PointsType.REDEEM })
+      .getRawOne();
+
+    const activeUsers = await this.transactionRepo
+      .createQueryBuilder('tx')
+      .select('COUNT(DISTINCT tx.userId)', 'count')
+      .where('tx.programId = :programId', { programId })
+      .getRawOne();
+
+    return {
+      totalEarned: parseInt(totalEarned.sum) || 0,
+      totalRedeemed: parseInt(totalRedeemed.sum) || 0,
+      activeUsers: parseInt(activeUsers.count) || 0,
+    };
+  }
+
+  /**
+   * Cron job that runs daily at midnight to expire points.
+   */
+  @Cron(CronExpression.EVERY_DAY_AT_MIDNIGHT, { timeZone: 'Africa/Lagos' })
+  async expirePoints() {
+    const now = new Date();
+    this.logger.log('Running points expiration job');
+
+    // Find all earned transactions that have expiredDate <= now and not yet expiredLogged
+    const toExpire = await this.transactionRepo.find({
+      where: {
+        type: PointsType.EARN,
+        expirationDate: LessThan(now),
+      },
+      relations: ['user', 'program'],
+    });
+
+    for (const tx of toExpire) {
+      // Check if already logged as EXPIRE
+      const existingExpire = await this.transactionRepo.findOne({
+        where: {
+          user: { id: tx.user.id },
+          program: { id: tx.program.id },
+          type: PointsType.EXPIRE,
+          metadata: JSON.stringify({ originalTxId: tx.id }),
+        },
+      });
+      if (existingExpire) continue;
+
+      // Create an expire transaction
+      const expireTx = this.transactionRepo.create({
+        user: tx.user,
+        program: tx.program,
+        type: PointsType.EXPIRE,
+        points: tx.points,
+        metadata: { originalTxId: tx.id },
+        expirationDate: now, // expiration for expire entries can be now
+      });
+      await this.transactionRepo.save(expireTx);
+
+      // Notify user about expiration
+      this.notificationService.sendPointsExpiredNotification(
+        tx.user.id,
+        tx.points,
+      );
+    }
+  }
+}


### PR DESCRIPTION
closes #11  ## Summary
This PR introduces a complete Customer Loyalty Program module into our NestJS application. It includes:
- Entities for LoyaltyProgram, LoyaltyTier, PointsTransaction, and Reward
- DTOs for creating point transactions and redeeming rewards
- LoyaltyService methods for earning/redeeming points, tier upgrades, reward catalog, analytics, and a daily cron job to expire points
- LoyaltyController endpoints for creating transactions, redeeming rewards, listing rewards, fetching user tier, and returning basic analytics 
- Integration with NotificationService to send points-earned, points-redeemed, tier-upgrade, reward-redemption, and points-expiration notifications
- Basic documentation of endpoints and expected request/response payloads

## Changes
1. **Entities**  
   - `loyalty-program.entity.ts`  
   - `loyalty-tier.entity.ts`  
   - `points.entity.ts` (renamed to `PointsTransaction`)  
   - `reward.entity.ts`

2. **DTOs**  
   - `create-transaction.dto.ts`  
   - `redeem-reward.dto.ts`

3. **Service**  
   - `loyalty.service.ts`  
     - `createTransaction()` for earning/redeeming points  
     - `calculateUserBalance()` excludes expired/redeemed points  
     - `checkAndUpgradeTier()` to assign the correct loyalty tier  
     - `redeemReward()` to validate balance/stock, deduct points, decrement stock  
     - `listRewards()` to return all rewards in a program  
     - `getAnalytics()` to report total earned, redeemed, and active users  
     - `@Cron(…) expirePoints()` job to automatically log expired‐points transactions and notify users  

4. **Controller**  
   - `loyalty.controller.ts`  
     - `POST /loyalty/transaction`  
     - `POST /loyalty/redeem`  
     - `GET  /loyalty/rewards/:programId`  
     - `GET  /loyalty/tier/:programId`  
     - `GET  /loyalty/analytics/:programId`

5. **Module Registration**  
   - `loyalty.module.ts` importing TypeORM entities and NotificationModule  

6. **Documentation**  
   - README snippet or `loyalty.md` included (in `docs/`) describing all endpoints, DTO shapes, and error conditions.

## Tasks / Acceptance Criteria Covered
- **Create LoyaltyProgram and Points entities**  
  ✓ Defined `LoyaltyProgram`, `LoyaltyTier`, `PointsTransaction` (with earning/redeem/expire)  
- **Implement points earning and redemption**  
  ✓ `createTransaction()` handles both `earn` and `redeem` logic, including balance check for redemption  
- **Build loyalty tier management**  
  ✓ `checkAndUpgradeTier()` runs after earning points and updates a user’s tier if thresholds are met  
- **Create reward catalog and redemption**  
  ✓ `Reward` entity, `listRewards()`, and `redeemReward()` with stock-check and points deduction  
- **Implement points expiration handling**  
  ✓ Daily Cron job logs expired points as `EXPIRE` transactions and notifies users  
- **Build loyalty analytics**  
  ✓ `getAnalytics()` returns total points earned/redeemed and active user count  
- **Set up loyalty notifications**  
  ✓ Integrated calls to `NotificationService.send…Notification()` at each key step (earn, redeem, tier upgrade, expiration, reward redemption)

## How to Test
1. **Database Migrations / Sync**  
   - Run `npm run typeorm:sync` (or your migration workflow) to create the new tables.  
2. **Create a Loyalty Program**  
   - Manually insert a `LoyaltyProgram` row (or add an endpoint). Ensure `pointsExpirationDays` is set (e.g. 365).  
   - Insert a few `LoyaltyTier` rows (Bronze: 0, Silver: 1000, Gold: 5000).  
   - Insert some `Reward` rows (e.g. “$10 Gift Card” for 1000 points, stock 50).  
3. **Earning Points**  
   - As an authenticated user, `POST /loyalty/transaction { programId, type: "earn", points: 500 }`  
   - Verify a row in `points_transactions` with type `earn`, expirationDate = today + 365 days.  
   - Verify the user’s tier remains Bronze (0 minPoints) if total < 1000.  
4. **Tier Upgrade**  
   - Earn enough points: `POST /loyalty/transaction { points: 1200 }`  
   - Confirm `loyalty_tiers` lookup finds Silver (minPoints 1000) and that user.loyaltyTier is updated.  
   - Check that a “tier upgrade” notification was enqueued or sent.  
5. **Redeeming Points**  
   - Assuming current balance ≥ reward’s pointsCost, call `POST /loyalty/redeem { programId, rewardId }`.  
   - Confirm a new `points_transactions` row with type `redeem` is created, and `reward.stock` is decremented.  
   - Confirm a “reward redemption” notification was sent.  
6. **Expiration Cron**  
   - Temporarily reduce `pointsExpirationDays` to 0 in a test program, create an earn transaction, wait until the cron runs (or manually invoke `loyaltyService.expirePoints()`), and verify an `EXPIRE` transaction is logged and user is notified.  
7. **Analytics & Listing**  
   - `GET /loyalty/analytics/:programId` should return correct sums and active user count.  
   - `GET /loyalty/rewards/:programId` should list all available rewards, ordered by cost.  
8. **Edge Cases**  
   - Attempt to redeem more points than balance → expect `400 Bad Request: Insufficient points to redeem`  
   - Attempt to redeem out‐of‐stock reward → expect `400 Bad Request: Reward is out of stock`  
   - Cron job runs multiple times for the same expired transaction → no duplicate `EXPIRE` entries due to metadata check.
closes #49 


